### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Christoph Haberer,Mario Patino,Giovanni Giorgi
 maintainer=Giovani Giorgi
 sentence=MOS6581 Stereo SID Emulator Arduino Library
 paragraph=This library emulates the SID sound chip of the famous Commodore 64 with enhanched stereo support.
+category=Other
 url=http://gioorgi.com/tag/stereosid/
 architectures=avr


### PR DESCRIPTION
This will fix the
`WARNING: Category '' in library StereoSID is not valid. Setting to 'Uncategorized'`
warning in Arduino IDE 1.6.6 and onwards. I chose the `Other` category because that was the previous value set in https://github.com/daitangio/sid-arduino-lib/commit/5e15eb8d7cf2e2c0b9b466a4c014822df3b1b475(and removed in https://github.com/daitangio/sid-arduino-lib/commit/bd294355bc23291b7cd759eabbd9d9d7444848cf for some reason) but I'm happy to change it to any other [valid category value](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
